### PR TITLE
Feat/convert links option

### DIFF
--- a/src/SiteToMarkdown/Options.cs
+++ b/src/SiteToMarkdown/Options.cs
@@ -12,4 +12,7 @@ public class Options
 
     [Option("filter-class", HelpText = "Ignores all HTML tags with the given classes", Separator = ',')]
     public IEnumerable<string> ClassFilters { get; set; } = [];
+
+    [Option('c', "convert-links", HelpText = "EXPERIMENTAL! Convert links to markdown format")]
+    public bool ConvertLinks { get; set; } = false;
 }

--- a/src/SiteToMarkdown/Program.cs
+++ b/src/SiteToMarkdown/Program.cs
@@ -32,8 +32,18 @@ var converter = new ReverseMarkdown.Converter(new ReverseMarkdown.Config
 var mdFilename = Utils.UriToMarkdownFileName(url);
 
 var web = new HtmlWeb();
-var docs = Utils.ScrapeUrl(web, url)
-    .Select(doc => Utils.FilterHtmlTags(doc, options.IdFilters, options.ClassFilters));
+
+IEnumerable<HtmlDocument> docs;
+if (options.ConvertLinks)
+{
+    docs = Utils.ConvertLinks(Utils.ScrapeSiteAndUrl(web, url));
+}
+else
+{
+    docs = Utils.ScrapeUrl(web, url);
+}
+
+docs = docs.Select(doc => Utils.FilterHtmlTags(doc, options.IdFilters, options.ClassFilters));
 
 var converted = docs
     .Select(static doc => doc.DocumentNode.InnerHtml)

--- a/src/SiteToMarkdown/Utils.cs
+++ b/src/SiteToMarkdown/Utils.cs
@@ -157,10 +157,15 @@ public static class Utils
 
     public static List<HtmlDocument> ConvertLinks(IEnumerable<(Uri Url, HtmlDocument Doc)> values)
     {
-        var valuesList = values
+        List<(Uri Url, HtmlDocument Doc, string markdownAnchor)> valuesList = values
             .Select(x =>
             {
                 var h1 = x.Doc.DocumentNode.SelectSingleNode("//h1");
+                if (h1 is null)
+                {
+                    return (x.Url, x.Doc, string.Empty);
+                }
+
                 var title = h1!.InnerText;
                 var titleAnchor = title
                     .Trim()
@@ -173,6 +178,7 @@ public static class Utils
             .ToList();
 
         var anchorMap = valuesList
+            .Where(x => !string.IsNullOrEmpty(x.markdownAnchor))
             .ToDictionary(
                 x => x.Url,
                 x => x.markdownAnchor);

--- a/src/SiteToMarkdown/Utils.cs
+++ b/src/SiteToMarkdown/Utils.cs
@@ -115,7 +115,11 @@ public static class Utils
         return document;
     }
 
-    public static IEnumerable<HtmlDocument> ScrapeUrl(HtmlWeb web, Uri url)
+    public static IEnumerable<HtmlDocument> ScrapeUrl(HtmlWeb web, Uri url) =>
+        ScrapeSiteAndUrl(web, url)
+            .Select(static tuple => tuple.Item2);
+
+    public static IEnumerable<(Uri, HtmlDocument)> ScrapeSiteAndUrl(HtmlWeb web, Uri url)
     {
         ArgumentNullException.ThrowIfNull(web);
         ArgumentNullException.ThrowIfNull(url);
@@ -147,7 +151,65 @@ public static class Utils
             }
 
             EnqueueRelevantLinks(doc, url, pagesDiscovered, pagesToScrape);
-            yield return doc;
+            yield return (currentUrl, doc);
         }
+    }
+
+    public static List<HtmlDocument> ConvertLinks(IEnumerable<(Uri Url, HtmlDocument Doc)> values)
+    {
+        var valuesList = values
+            .Select(x =>
+            {
+                var h1 = x.Doc.DocumentNode.SelectSingleNode("//h1");
+                var title = h1!.InnerText;
+                var titleAnchor = title
+                    .Trim()
+                    .Replace(' ', '-')
+                    .ToLowerInvariant();
+                var markdownAnchor = $"[{title}](#{titleAnchor})";
+
+                return (x.Url, x.Doc, markdownAnchor);
+            })
+            .ToList();
+
+        var anchorMap = valuesList
+            .ToDictionary(
+                x => x.Url,
+                x => x.markdownAnchor);
+
+        foreach(var (url, doc, anchor) in valuesList)
+        {
+            anchorMap[new Uri(url.AbsolutePath, UriKind.RelativeOrAbsolute)] = anchor;
+        }
+
+        var docs = valuesList
+            .Select(static x => x.Doc)
+            .ToList();
+        foreach (var doc in docs)
+        {
+            var links = doc.DocumentNode.SelectNodes("//a[@href]");
+            if (links is null)
+            {
+                continue;
+            }
+
+            foreach (var link in links)
+            {
+                var href = link.GetAttributeValue("href", string.Empty);
+                if (string.IsNullOrEmpty(href)
+                    || !Uri.TryCreate(href, UriKind.RelativeOrAbsolute, out var result)
+                    || !anchorMap.TryGetValue(result, out var anchor))
+                {
+                    continue;
+                }
+
+                link.ParentNode.InsertBefore(
+                    HtmlNode.CreateNode($"<p>{anchor}</p>"),
+                    link);
+                link.Remove();
+            }
+        }
+
+        return docs;
     }
 }

--- a/src/SiteToMarkdown/example/index.html
+++ b/src/SiteToMarkdown/example/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Main example document</title>
+</head>
+<body>
+    <h1 id="welcome-to-main">Welcome to the Main Example Document</h1>
+    <p>This is the main example document for the SiteToMarkdown project.</p>
+    <a href="/subpage.html">Go to Subpage</a>
+    <h2>Subsection</h2>
+    <p>This is a subsection of the main document.</p>
+    <a href="#welcome-to-main">Back to Top</a>
+</body>
+</html>

--- a/src/SiteToMarkdown/example/index.html.md
+++ b/src/SiteToMarkdown/example/index.html.md
@@ -1,0 +1,23 @@
+﻿# Welcome to the Main Example Document
+
+This is the main example document for the SiteToMarkdown project.
+
+[Welcome to the Subpage Example Document](#welcome-to-the-subpage-example-document)
+
+## Subsection
+
+This is a subsection of the main document.
+
+    Back to Top
+
+# Welcome to the Subpage Example Document
+
+This is a subpage example document for the SiteToMarkdown project.
+
+[Welcome to the Main Example Document](#welcome-to-the-main-example-document)
+
+## Subsection of Subpage
+
+This is a subsection of the subpage document.
+
+    Back to Top

--- a/src/SiteToMarkdown/example/subpage.html
+++ b/src/SiteToMarkdown/example/subpage.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Subpage Example Document</title>
+</head>
+<body>
+    <h1 id="welcome-to-subpage">Welcome to the Subpage Example Document</h1>
+    <p>This is a subpage example document for the SiteToMarkdown project.</p>
+    <a href="/index.html">Go to Main Page</a>
+    <h2>Subsection of Subpage</h2>
+    <p>This is a subsection of the subpage document.</p>
+    <a href="#welcome-to-subpage">Back to Top</a>
+</body>
+</html>


### PR DESCRIPTION
This flag *only* looks for `<h1>` tags on each url and replaces all references to that url with a markdown compatible link

Look in examples folder to see how this works.

OBS: This method is only to create a slightly better user friendly way to go through the final markdown file, but it does *not* take into account whether multiple pages have the same header or if the pages do not even have `<h1>` tags